### PR TITLE
Added support for investments in ING

### DIFF
--- a/bank_scrap.gemspec
+++ b/bank_scrap.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/bank-scrap/bank_scrap"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split('\x0')
+  spec.files         = Dir['README.md', 'lib/**/{*,.[a-z]*}']
   spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ['lib']

--- a/bank_scrap.gemspec
+++ b/bank_scrap.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
     'Fernando Blat',
     'Raúl Marcos'
   ]
-  spec.email         = ["root@ismagnu.com"]
+  spec.email         = ['root@ismagnu.com']
   spec.summary       = %q{Get your bank account details.}
   spec.description   = %q{Command line tools to get bank account details from some banks.}
   spec.homepage      = "https://github.com/bank-scrap/bank_scrap"
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~> 2.1'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'byebug', '~> 3.5', '>= 3.5.1'
+  spec.add_development_dependency 'rake',    '~> 10.0'
+  spec.add_development_dependency 'byebug',  '~> 3.5', '>= 3.5.1'
 
   spec.add_dependency 'thor',          '~> 0.19'
   spec.add_dependency 'nokogiri',      '~> 1.6'

--- a/lib/bank_scrap.rb
+++ b/lib/bank_scrap.rb
@@ -6,6 +6,7 @@ require 'bank_scrap/config'
 require 'bank_scrap/cli'
 require 'bank_scrap/bank'
 require 'bank_scrap/account'
+require 'bank_scrap/investment'
 require 'bank_scrap/transaction'
 
 module BankScrap

--- a/lib/bank_scrap/bank.rb
+++ b/lib/bank_scrap/bank.rb
@@ -4,16 +4,20 @@ require 'logger'
 module BankScrap
   class Bank
     WEB_USER_AGENT = 'Mozilla/5.0 (Linux; Android 4.2.1; en-us; Nexus 4 Build/JOP40D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19'
-    attr_accessor :headers, :accounts
+    attr_accessor :headers, :accounts, :investments
 
     def initialize(user, password, log: false, debug: false, extra_args: nil)
-      @accounts = fetch_accounts
+      @accounts    = fetch_accounts
     end
 
     # Interface method placeholders
 
     def fetch_accounts
       fail "#{self.class} should implement a fetch_account method"
+    end
+
+    def fetch_investments
+      fail "#{self.class} should implement a fetch_investment method"
     end
 
     def fetch_transactions_for(*)

--- a/lib/bank_scrap/banks/ing.rb
+++ b/lib/bank_scrap/banks/ing.rb
@@ -25,6 +25,8 @@ module BankScrap
       initialize_connection
       bundled_login
 
+      @investments = fetch_investments
+
       super
     end
 
@@ -48,10 +50,20 @@ module BankScrap
         'Content-Type' => 'application/json; charset=utf-8'
       )
 
-      @raw_accounts_data = JSON.parse(get(PRODUCTS_ENDPOINT))
-
-      @raw_accounts_data.map do |account|
+      JSON.parse(get(PRODUCTS_ENDPOINT)).map do |account|
         build_account(account) if account['iban']
+      end.compact
+    end
+
+    def fetch_investments
+      log 'fetch_investments'
+      add_headers(
+        'Accept'       => '*/*',
+        'Content-Type' => 'application/json; charset=utf-8'
+      )
+
+      JSON.parse(get(PRODUCTS_ENDPOINT)).map do |investment|
+        build_investment(investment) if investment['investment']
       end.compact
     end
 
@@ -200,6 +212,17 @@ module BankScrap
         description: (data['alias'] || data['name']),
         iban: data['iban'],
         bic: data['bic']
+      )
+    end
+
+    def build_investment(data)
+      Investment.new(
+        bank: self,
+        id: data['uuid'],
+        name: data['name'],
+        balance: data['balance'],
+        currency: 'EUR',
+        investment: data['investment']
       )
     end
 

--- a/lib/bank_scrap/banks/ing.rb
+++ b/lib/bank_scrap/banks/ing.rb
@@ -1,6 +1,6 @@
 require 'json'
 require 'base64'
-require 'RMagick'
+require 'rmagick'
 require 'tempfile'
 
 module BankScrap

--- a/lib/bank_scrap/investment.rb
+++ b/lib/bank_scrap/investment.rb
@@ -1,0 +1,18 @@
+module BankScrap
+  class Investment
+    include Utils::Inspectable
+
+    attr_accessor :bank, :id, :name, :balance, :currency, :investment
+
+    def initialize(params = {})
+      params.each { |key,value| send "#{key}=", value }
+    end
+
+    private
+      def inspect_attributes
+        [
+          :id, :name, :balance, :currency, :investment
+        ]
+      end
+  end
+end


### PR DESCRIPTION
In the endpoint to retrieve the accounts, ING also provides info about investment funds. These accounts are a bit different, so I've created a new class (trying to keep it minimal, without data that maybe other banks don't provide).

I've decided to call `fetch_investments` locally in the ING class to avoid breaking other integrations. If we can get those kind of info from more banks, I think we should force to implement `fetch_investments` in all integrations adding it to bank.rb.

BTW, I've also modified the gemspec to remove git ls-files, it was impossible to do `rake install` and it's better not being git-dependant (thanks @mikz)