### PR TITLE
Fix: Include balance attributes on BBVA transactions

### DIFF
--- a/lib/bank_scrap/banks/bbva.rb
+++ b/lib/bank_scrap/banks/bbva.rb
@@ -57,7 +57,6 @@ module BankScrap
     # Returns an array of BankScrap::Transaction objects
     def fetch_transactions_for(account, start_date: Date.today - 1.month, end_date: Date.today)
       from_date = start_date.strftime('%Y-%m-%d')
-      to_date   = end_date.strftime('%Y-%m-%d')
 
       # Misteriously we need a specific content-type here
       funny_headers = {
@@ -65,24 +64,36 @@ module BankScrap
         'BBVA-Method' => 'GET'
       }
 
+      # The API accepts a toDate param that we could pass the end_date argument,
+      # however when we pass the toDate param, the API stops returning the account balance.
+      # Therefore we need to take a workaround: only filter with fromDate and loop 
+      # over all the available pages, filtering out the movements that doesn't match
+      # the end_date argument.
       url = BASE_ENDPOINT +
             ACCOUNT_ENDPOINT +
             account.id +
-            "/movements/v1?fromDate=#{from_date}&toDate=#{to_date}"
+            "/movements/v1?fromDate=#{from_date}"
+            
       offset = nil
+      pagination_balance = nil
       transactions = []
 
       with_headers(funny_headers) do
         # Loop over pagination
         loop do
           new_url = offset ? (url + "&offset=#{offset}") : url
+          new_url = pagination_balance ? (new_url + "&paginationBalance=#{pagination_balance}") : new_url
           json = JSON.parse(post(new_url, {}))
 
           unless json['movements'].blank?
-            transactions += json['movements'].map do |data|
+            # As explained before, we have to discard records newer than end_date. 
+            filtered_movements = json['movements'].select { |m| Date.parse(m['operationDate']) <= end_date }
+            
+            transactions += filtered_movements.map do |data|
               build_transaction(data, account)
             end
             offset = json['offset']
+            pagination_balance = json['paginationBalance']
           end
 
           break unless json['thereAreMoreMovements'] == true


### PR DESCRIPTION
Before this PR bbva transactions weren't including balance details attached. After some research I realized this was caused by the `toDate` param included in the API call. It's hard to understand for me why this work this way within bbva API but it's true. The only way to get records from the API with the balance included is by not using `toDate` param. This means that all the calls we do to the API are going to include movements that we might not need because they are newer than the `end_date`. In that case the loop will be responsible of discard them and keep all those matching the date range supplied. 

Besides the `toDate` param thing, it's needed to attach the `paginationBalance` parameter which comes given in each API request.